### PR TITLE
fix empty space left by hidden columns

### DIFF
--- a/content-script.css
+++ b/content-script.css
@@ -14,6 +14,10 @@
     display: none !important;
 }
 
+.hide-col {
+    width: 0 !important;
+}
+
 .color-alfa0 {
     color:rgba(0,0,0,0);
 }

--- a/content-script.js
+++ b/content-script.js
@@ -96,17 +96,10 @@ function toggleByColName(colName, checked) {
     if (colNo) {
         temp = document.querySelectorAll('table tr td:nth-child(' + (colNo + 1) + ')');
         if (checked) {
-            document.querySelector('table tr th:nth-child(' + (colNo + 1) + ')').classList.remove('hide');
-
-            for (i = 0; i < temp.length; i++) {
-                temp[i].classList.remove('hide');
-            }
+            document.querySelector(`colgroup > col:nth-child(${colNo + 1})`).classList.remove('hide-col');
         }
         else {
-            document.querySelector('table tr th:nth-child(' + (colNo + 1) + ')').classList.add('hide');
-            for (i = 0; i < temp.length; i++) {
-                temp[i].classList.add('hide');
-            }
+            document.querySelector(`colgroup > col:nth-child(${colNo + 1})`).classList.add('hide-col');
         }
     }
 }


### PR DESCRIPTION
fixes hidden columns leaving empty spaces by setting width to 0 on the
col element instead of using display:none