### PR TITLE
Hiding user previous submission feature

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -173,7 +173,9 @@ function applyChanges(options) {
             hideSolvedProb(option.checked)
         } else if(name === 'disUsers') {
             setSolutionsUsers(option.checked)
-        } 
+        } else if(name == 'submissions') {
+            setHideSubmission(option.checked)
+        }
         else {
             toggleByColName(name, option.checked);
         }
@@ -604,5 +606,20 @@ function setSolutionsUsers(checked) {
             }
         }
 
+    }
+}
+
+// ################## HIDE USERS PREVIOUS SUBMISSIONS #######################
+
+const setHideSubmission = (checked) => {
+    const submissionSection = document.querySelector('#qd-content > div.h-full.flex-col.ssg__qd-splitter-primary-w > div > div > div > div.flex.h-full.w-full.overflow-y-auto.rounded-b > div > div.h-full');
+
+    if(checked)
+    {
+        submissionSection.classList.remove('hide');
+    }
+    else
+    {
+        submissionSection.classList.add('hide');
     }
 }

--- a/content-script.js
+++ b/content-script.js
@@ -618,11 +618,11 @@ const setHideTab = (checked, tabValue) => {
         {
             if (checked) 
             {
-                tab.style.display = 'block';
+                tab.classList.remove('hide');
             } 
             else 
             {
-                tab.style.display = 'none';
+                tab.classList.add('hide');
             }
             return;
         }

--- a/content-script.js
+++ b/content-script.js
@@ -174,9 +174,8 @@ function applyChanges(options) {
         } else if(name === 'disUsers') {
             setSolutionsUsers(option.checked)
         } else if(name == 'submissions') {
-            setHideSubmission(option.checked)
-        }
-        else {
+            setHideTab(option.checked, 'Submissions')
+        }else {
             toggleByColName(name, option.checked);
         }
     }
@@ -609,17 +608,23 @@ function setSolutionsUsers(checked) {
     }
 }
 
-// ################## HIDE USERS PREVIOUS SUBMISSIONS #######################
+// ################## HIDE TAB such as Editorial, Solutions and Submissions FROM THE CODING AREA #######################
 
-const setHideSubmission = (checked) => {
-    const submissionSection = document.querySelector('#qd-content > div.h-full.flex-col.ssg__qd-splitter-primary-w > div > div > div > div.flex.h-full.w-full.overflow-y-auto.rounded-b > div > div.h-full');
+const setHideTab = (checked, tabValue) => {
+    const tabList = document.querySelectorAll('#qd-content > div.h-full.flex-col.ssg__qd-splitter-primary-w > div > div > div > div > div > div > a > div > span');
 
-    if(checked)
-    {
-        submissionSection.classList.remove('hide');
-    }
-    else
-    {
-        submissionSection.classList.add('hide');
-    }
+    tabList.forEach(tab => {
+        if (tab.innerText.trim() === tabValue) 
+        {
+            if (checked) 
+            {
+                tab.style.display = 'block';
+            } 
+            else 
+            {
+                tab.style.display = 'none';
+            }
+            return;
+        }
+    })
 }

--- a/popup.html
+++ b/popup.html
@@ -49,10 +49,15 @@
                 <input id="solved" checked type="checkbox" name="settings" value="solved">
                 <label for="solved" class="checkbox-label"></label>
             </div>
-            <div style="margin-bottom: 15px;" class="option-div">
+            <div class="option-div">
                 <label for="disUsers"> Solutions Users' Profile Images</label>
                 <input id="disUsers" checked type="checkbox" name="settings" value="disUsers">
                 <label for="disUsers" class="checkbox-label"></label>
+            </div>
+            <div class="option-div" style="margin-bottom: 15px;">
+                <label for="submissions"> Submissions </label>
+                <input id="submissions" checked type="checkbox" name="settings" value="submissions">
+                <label for="submissions" class="checkbox-label"></label>
             </div>
 
             <fieldset>

--- a/popup.html
+++ b/popup.html
@@ -49,15 +49,10 @@
                 <input id="solved" checked type="checkbox" name="settings" value="solved">
                 <label for="solved" class="checkbox-label"></label>
             </div>
-            <div class="option-div">
+            <div class="option-div" style="margin-bottom: 15px;">
                 <label for="disUsers"> Solutions Users' Profile Images</label>
                 <input id="disUsers" checked type="checkbox" name="settings" value="disUsers">
                 <label for="disUsers" class="checkbox-label"></label>
-            </div>
-            <div class="option-div" style="margin-bottom: 15px;">
-                <label for="submissions"> Submissions </label>
-                <input id="submissions" checked type="checkbox" name="settings" value="submissions">
-                <label for="submissions" class="checkbox-label"></label>
             </div>
 
             <fieldset>
@@ -68,9 +63,14 @@
                     <label for="status" class="checkbox-label"></label>
                 </div>
                 <div class="option-div">
-                    <label for="solution"> Solution </label>
+                    <label for="solution"> Solutions </label>
                     <input id="solution" checked type="checkbox" name="settings" value="solution">
                     <label for="solution" class="checkbox-label"></label>
+                </div>
+                <div class="option-div">
+                    <label for="submissions"> Submissions </label>
+                    <input id="submissions" checked type="checkbox" name="settings" value="submissions">
+                    <label for="submissions" class="checkbox-label"></label>
                 </div>
                 <div class="option-div"> 
                     <label for="acceptance"> Acceptance </label>


### PR DESCRIPTION
If a user, such as me, has a bad habit of constantly referring to their previously submitted solutions while revisiting code and revising questions, it can hinder productivity. To address this issue, I have implemented a new feature that allows you to hide or unhide previous submissions. I have added a checkbox labeled "Submissions" which enables you to hide the previous solutions and focus solely on the task at hand. This feature aims to boost productivity by minimizing distractions and encouraging independent problem-solving.